### PR TITLE
Support PyPy 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
     - "3.6"
     - "nightly"
     - "pypy-5.4"
+    - "pypy3"
 
 env:
     -

--- a/examples/good/simple.rst
+++ b/examples/good/simple.rst
@@ -1,0 +1,34 @@
+====
+Test
+====
+
+.. code-block:: bash
+
+    if [ "$x" == 'y' ]
+    then
+        exit 1
+    fi
+
+.. code-block:: c
+
+    float foo(int n)
+    {
+        // Test C99.
+        float x[n];
+        x[0] = 1;
+        return x[0];
+    }
+
+.. code-block:: cpp
+
+    #include <iostream>
+
+    int main()
+    {
+        auto x = 1;
+        return x;
+    }
+
+.. code-block:: python
+
+    print(1)

--- a/rstcheck.py
+++ b/rstcheck.py
@@ -270,6 +270,11 @@ def check_python(code):
         yield (int(exception.lineno), exception.msg)
 
 
+def character_index_to_line_number(text, character_index):
+    """Return (1-indexed) line number of the character index."""
+    return text.count('\n', 0, character_index) + 1
+
+
 def check_json(code):
     """Yield errors."""
     try:
@@ -281,6 +286,12 @@ def check_json(code):
         found = re.search(r': line\s+([0-9]+)[^:]*$', message)
         if found:
             line_number = int(found.group(1))
+        else:
+            found = re.search(r'\(char\s+([0-9]+)\)', message)
+            if found:
+                line_number = character_index_to_line_number(
+                    text=code,
+                    character_index=int(found.group(1)))
 
         yield (int(line_number), message)
 

--- a/test.bash
+++ b/test.bash
@@ -29,7 +29,7 @@ done
 
 ./rstcheck.py --ignore-language=cpp examples/bad/bad_cpp.rst
 
-./rstcheck.py - < examples/good/good.rst
+./rstcheck.py - < examples/good/simple.rst
 ./rstcheck.py examples/with_configuration/good.rst
 
 # Test multiple mix of good/bad files.

--- a/test_rstcheck.py
+++ b/test_rstcheck.py
@@ -82,7 +82,7 @@ Test
 .. code-block:: json
 
     {
-        'abc': 123
+        "abc": 123:
     }
 """))
 
@@ -97,7 +97,7 @@ Test
 .. code-block:: json
 
     {
-        'abc': 123
+        "abc": 123:
     }
 
 .. rstcheck: ignore-language=json,python,rst
@@ -114,7 +114,7 @@ Test
 .. code-block:: json
 
     {
-        'abc': 123
+        "abc": 123:
     }
 
 .. rstcheck: ignore-language=cpp,python,rst
@@ -131,7 +131,7 @@ Test
 .. code-block:: json
 
     {
-        'abc': 123
+        "abc": 123:
     }
 
 .. rstcheck: ignore-language json,python,rst


### PR DESCRIPTION
The optimized PyPy JSON decoder only prints out character indexes.

This fixes #29.