### PR TITLE
Fix using same reference to args

### DIFF
--- a/rstcheck.py
+++ b/rstcheck.py
@@ -30,6 +30,7 @@ from __future__ import unicode_literals
 
 import argparse
 import contextlib
+import copy
 import doctest
 import io
 import json
@@ -922,7 +923,7 @@ def main():
                 # mutating the settings when rstcheck is used as a module.
                 results = pool.map(
                     _check_file,
-                    [(name, args) for name in args.files])
+                    [(name, copy.copy(args)) for name in args.files])
             else:
                 # This is for the case where we read from standard in.
                 results = [_check_file((args.files[0], args))]


### PR DESCRIPTION
When checking several files, the same reference to ``args`` is used and the ``load_configuration_from_file`` function fails. This is the faster solution I came up.