### PR TITLE
Close the multiprocessing.pool after use

### DIFF
--- a/rstcheck.py
+++ b/rstcheck.py
@@ -981,6 +981,8 @@ def main():
         except (IOError, UnicodeError) as exception:
             output_message(exception)
             status = 1
+        finally:
+            pool.close()
 
         return status
 


### PR DESCRIPTION
So that the tests do not hang intermittently

When preparing to release Alpine Linux 3.12, the tests for this package
would hang intermittently. This problem was isolated to the tests in
test.bash that run rstcheck.py over multiple files.

The documentation for multiprocessing.pool explains that:

> Warning multiprocessing.pool objects have internal resources that need
> to be properly managed (like any other resource) by using the pool as
> a context manager or by calling close() and terminate() manually.
> Failure to do this can lead to the process hanging on finalization.

> Note that is not correct to rely on the garbage colletor to destroy
> the pool as CPython does not assure that the finalizer of the pool
> will be called (see object.__del__() for more information).

https://docs.python.org/3/library/multiprocessing.html#module-multiprocessing.pool

Before this commit close() was not called on the multiprocessing pool;
after this commit close() is called.

The change in this commit was tested in an Alpine Linux container:

    podman run -ti --rm -v $PWD:/srv:Z -w /srv alpine:edge sh

By running:

    apk add alpine-sdk python3 py3-docutils py3-setuptools bash
    python3 setup.py build
    sed -i '1s|^#!/usr/bin/env python$|#!/usr/bin/python3|' rstcheck.py
    python3 ./test_rstcheck.py
    bash ./test.bash