### PR TITLE
sphinx integration rework

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -246,7 +246,7 @@ constraint is >=4.0 because of Sphinx's open upper constraints on jinja2 and mar
 which result in import errors if not pinned below version 3 and 2 respectively. This happend
 in Sphinx version 4.0.
 
-You can also add Sphinx by yourself but the installed Sphinx version must be at least 1.5.
+You can also add Sphinx by yourself but the installed Sphinx version must be at least 2.0.
 
 To check that Sphinx support is enabled
 
@@ -371,6 +371,13 @@ History
 
 (next version)
 --------------
+
+.. _beaking_changes_v6:
+
+BREAKING CHANGES
+~~~~~~~~~~~~~~~~
+
+- Drop support for sphinx < 2.0
 
 
 5.0.0 (2022-04-17)

--- a/README.rst
+++ b/README.rst
@@ -372,12 +372,16 @@ History
 (next version)
 --------------
 
+- Fix inability to ignore ``code``, ``code-block`` and ``sourcecode`` directives (#79)
+- Fix ``code-block`` options recognition (#62)
+
 .. _beaking_changes_v6:
 
 BREAKING CHANGES
 ~~~~~~~~~~~~~~~~
 
 - Drop support for sphinx < 2.0
+- Drop default values for directves and roles for sphinx (#65)
 
 
 5.0.0 (2022-04-17)

--- a/examples/bad/bad_bash.rst
+++ b/examples/bad/bad_bash.rst
@@ -2,6 +2,6 @@
 Test
 ====
 
-.. code-block:: bash
+.. code:: bash
 
     {

--- a/examples/bad/bad_code.rst
+++ b/examples/bad/bad_code.rst
@@ -2,8 +2,6 @@
 Test
 ====
 
-``code`` rather than ``code-block``.
-
 .. code:: python
 
     print(

--- a/examples/bad/bad_cpp.rst
+++ b/examples/bad/bad_cpp.rst
@@ -2,7 +2,7 @@
 Test
 ====
 
-.. code-block:: cpp
+.. code:: cpp
 
     int main()
     {

--- a/examples/bad/bad_python.rst
+++ b/examples/bad/bad_python.rst
@@ -2,6 +2,6 @@
 Test
 ====
 
-.. code-block:: python
+.. code:: python
 
     print(

--- a/examples/bad/bad_rst_in_rst.rst
+++ b/examples/bad/bad_rst_in_rst.rst
@@ -2,7 +2,7 @@
 Test
 ====
 
-.. code-block:: rst
+.. code:: rst
 
     Testing
     ===

--- a/examples/good/good.rst
+++ b/examples/good/good.rst
@@ -2,14 +2,14 @@
 Test
 ====
 
-.. code-block:: bash
+.. code:: bash
 
     if [ "$x" == 'y' ]
     then
         exit 1
     fi
 
-.. code-block:: c
+.. code:: c
 
     float foo(int n)
     {
@@ -19,7 +19,7 @@ Test
         return x[0];
     }
 
-.. code-block:: cpp
+.. code:: cpp
 
     #include <iostream>
 
@@ -29,20 +29,20 @@ Test
         return x;
     }
 
-.. code-block:: python
+.. code:: python
 
     print(1)
 
 Run more tests for checking performance.
 
-.. code-block:: bash
+.. code:: bash
 
     if [ "$x" == 'y' ]
     then
         exit 1
     fi
 
-.. code-block:: c
+.. code:: c
 
     float foo(int n)
     {
@@ -52,7 +52,7 @@ Run more tests for checking performance.
         return x[0];
     }
 
-.. code-block:: cpp
+.. code:: cpp
 
     #include <iostream>
 
@@ -62,18 +62,18 @@ Run more tests for checking performance.
         return x;
     }
 
-.. code-block:: python
+.. code:: python
 
     print(1)
 
-.. code-block:: bash
+.. code:: bash
 
     if [ "$x" == 'y' ]
     then
         exit 1
     fi
 
-.. code-block:: c
+.. code:: c
 
     float foo(int n)
     {
@@ -83,7 +83,7 @@ Run more tests for checking performance.
         return x[0];
     }
 
-.. code-block:: cpp
+.. code:: cpp
 
     #include <iostream>
 
@@ -93,18 +93,18 @@ Run more tests for checking performance.
         return x;
     }
 
-.. code-block:: python
+.. code:: python
 
     print(1)
 
-.. code-block:: bash
+.. code:: bash
 
     if [ "$x" == 'y' ]
     then
         exit 1
     fi
 
-.. code-block:: c
+.. code:: c
 
     float foo(int n)
     {
@@ -114,7 +114,7 @@ Run more tests for checking performance.
         return x[0];
     }
 
-.. code-block:: cpp
+.. code:: cpp
 
     #include <iostream>
 
@@ -124,18 +124,18 @@ Run more tests for checking performance.
         return x;
     }
 
-.. code-block:: python
+.. code:: python
 
     print(1)
 
-.. code-block:: bash
+.. code:: bash
 
     if [ "$x" == 'y' ]
     then
         exit 1
     fi
 
-.. code-block:: c
+.. code:: c
 
     float foo(int n)
     {
@@ -145,7 +145,7 @@ Run more tests for checking performance.
         return x[0];
     }
 
-.. code-block:: cpp
+.. code:: cpp
 
     #include <iostream>
 
@@ -155,7 +155,7 @@ Run more tests for checking performance.
         return x;
     }
 
-.. code-block:: python
+.. code:: python
 
     # ¬∆˚ß∂ƒß∂ƒ˚¬∆
     print(1)

--- a/examples/good/good_cpp_with_local_include.rst
+++ b/examples/good/good_cpp_with_local_include.rst
@@ -2,7 +2,7 @@
 Test
 ====
 
-.. code-block:: cpp
+.. code:: cpp
 
     #include "foo.h"
 

--- a/examples/good/good_markdown.rst
+++ b/examples/good/good_markdown.rst
@@ -2,6 +2,6 @@
 Test
 ====
 
-.. code-block:: markdown
+.. code:: markdown
 
     [Markdown-style Link](https://www.example.com/)

--- a/examples/good/unicode.rst
+++ b/examples/good/unicode.rst
@@ -2,11 +2,11 @@
 Тест
 ====
 
-.. code-block:: python
+.. code:: python
 
    print("Привет!")
 
-.. code-block:: bash
+.. code:: bash
 
     $ echo 'Привет' >> pipe.txt
     $ echo 'файловая труба!' >> pipe.txt

--- a/examples/good/unknown.rst
+++ b/examples/good/unknown.rst
@@ -1,5 +1,0 @@
-====
-Test
-====
-
-File reeference: :file:`~/.bashrc`.

--- a/examples/sphinx/good.rst
+++ b/examples/sphinx/good.rst
@@ -1,0 +1,5 @@
+====
+Test
+====
+
+File reeference: :file:`~/.bashrc`.

--- a/examples/with_configuration/bad.rst
+++ b/examples/with_configuration/bad.rst
@@ -3,7 +3,7 @@
 
 :some-custom-thing:`testing`
 
-.. code-block:: cpp
+.. code:: cpp
 
     int main()
     {

--- a/examples/with_configuration/good.rst
+++ b/examples/with_configuration/good.rst
@@ -3,7 +3,7 @@
 
 :some-custom-thing:`testing`
 
-.. code-block:: cpp
+.. code:: cpp
 
     int main()
     {

--- a/examples/without_configuration/good.rst
+++ b/examples/without_configuration/good.rst
@@ -3,7 +3,7 @@
 
 :some-custom-thing:`testing`
 
-.. code-block:: cpp
+.. code:: cpp
 
     int main()
     {

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -54,7 +54,7 @@ import typing_extensions
 try:
     import sphinx
 
-    SPHINX_INSTALLED = sphinx.version_info >= (1, 5)
+    SPHINX_INSTALLED = sphinx.version_info >= (2, 0)
 except (AttributeError, ImportError):
     SPHINX_INSTALLED = False
 

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -397,23 +397,34 @@ def _get_directives_and_roles_from_sphinx() -> typing.Tuple[typing.List[str], ty
 def _get_extended_default_directives_and_roles_for_sphinx() -> typing.Tuple[
     typing.List[str], typing.List[str]
 ]:
-    """Return a tuple of extended default Sphinx directive and roles.
+    """Return a tuple of Sphinx directive and roles.
 
-    These are used wether sphinx can be loaded or not.
+    These directive and roles cannot be loaded like the domain ones in
+    `_get_directives_and_roles_from_sphinx()`.
+
+    https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html
     """
-    sphinx_directives = [
+    sphinx_base_directives = [
         "centered",
-        "include",
+        "code-block",
+        "codeauthor",
         "deprecated",
-        "index",
-        "no-code-block",
-        "literalinclude",
+        "highlight",
         "hlist",
+        "include",
+        "index",
+        "literalinclude",
+        "math",
+        "note",
+        "only",
+        "rubric",
         "seealso",
+        "sectionauthor",
+        "tabularcolumns",
         "toctree",
-        "todo",
         "versionadded",
         "versionchanged",
+        "warning",
     ]
 
     ext_autosummary = [
@@ -421,9 +432,9 @@ def _get_extended_default_directives_and_roles_for_sphinx() -> typing.Tuple[
         "currentmodule",
     ]
 
-    sphinx_roles = ["ctype"]
+    sphinx_base_roles = ["ctype"]
 
-    return (sphinx_directives + ext_autosummary, sphinx_roles)
+    return (sphinx_base_directives + ext_autosummary, sphinx_base_roles)
 
 
 class IgnoredDirective(docutils.parsers.rst.Directive):

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -663,7 +663,7 @@ class CheckTranslator(docutils.nodes.NodeVisitor):
         document: docutils.nodes.document,
         file_contents: str,
         filename: str,
-        ignore: IgnoreDict,
+        ignore: typing.Optional[IgnoreDict],
     ) -> None:
         """Init CheckTranslator."""
         docutils.nodes.NodeVisitor.__init__(self, document)

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -514,7 +514,7 @@ def _ignore_role(
     return ([], [])
 
 
-def ignore_sphinx(use_sphinx_defaults: bool = False) -> None:
+def ignore_sphinx(use_sphinx_defaults: bool) -> None:
     """Register Sphinx directives and roles to ignore."""
     directives: typing.List[str] = []
     roles: typing.List[str] = []

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -144,6 +144,9 @@ def register_code_directive() -> None:
     """Register code directive."""
     if not SPHINX_INSTALLED:
         docutils.parsers.rst.directives.register_directive("code", CodeBlockDirective)
+        # NOTE: docutils maps `code-block` and `sourcecode` to `code`
+        docutils.parsers.rst.directives.register_directive("code-block", CodeBlockDirective)
+        docutils.parsers.rst.directives.register_directive("sourcecode", CodeBlockDirective)
 
 
 def strip_byte_order_mark(text: str) -> str:

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -902,6 +902,11 @@ def parse_args() -> argparse.Namespace:
         "-r", "--recursive", action="store_true", help="run recursively over directories"
     )
     parser.add_argument(
+        "--use-sphinx-defaults",
+        action="store_true",
+        help="run with default values for sphinx when it is not available",
+    )
+    parser.add_argument(
         "--report",
         metavar="level",
         choices=threshold_choices,

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -165,7 +165,7 @@ def strip_byte_order_mark(text: str) -> str:
         return text
 
 
-def check(  # noqa: CCR001 # pylint: disable=too-many-arguments
+def check(  # noqa: CCR001
     source: str,
     filename: str = "<string>",
     report_level: int = docutils.utils.Reporter.INFO_LEVEL,
@@ -671,7 +671,7 @@ def run_in_subprocess(
 class CheckTranslator(docutils.nodes.NodeVisitor):
     """Visits code blocks and checks for syntax errors in code."""
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         document: docutils.nodes.document,
         file_contents: str,
@@ -818,12 +818,7 @@ def beginning_of_code_block(
 class CheckWriter(docutils.writers.Writer):
     """Runs CheckTranslator on code blocks."""
 
-    def __init__(
-        self,
-        file_contents: str,
-        filename: str,
-        ignore: IgnoreDict,
-    ) -> None:
+    def __init__(self, file_contents: str, filename: str, ignore: IgnoreDict) -> None:
         """Init CheckWriter."""
         docutils.writers.Writer.__init__(self)
         self.checkers: typing.List[RunCheckFunction] = []

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -372,76 +372,82 @@ def split_comma_separated(text: str) -> typing.List[str]:
 
 
 def _get_directives_and_roles_from_sphinx() -> typing.Tuple[typing.List[str], typing.List[str]]:
-    """Return a tuple of Sphinx directive and roles."""
-    if SPHINX_INSTALLED:
-        sphinx_directives = list(sphinx.domains.std.StandardDomain.directives)
-        sphinx_roles = list(sphinx.domains.std.StandardDomain.roles)
+    """Return a tuple of Sphinx directive and roles loaded from sphinx."""
+    sphinx_directives = list(sphinx.domains.std.StandardDomain.directives)
+    sphinx_roles = list(sphinx.domains.std.StandardDomain.roles)
 
-        for domain in [
-            sphinx.domains.c.CDomain,
-            sphinx.domains.cpp.CPPDomain,
-            sphinx.domains.javascript.JavaScriptDomain,
-            sphinx.domains.python.PythonDomain,
-        ]:
+    for domain in [
+        sphinx.domains.c.CDomain,
+        sphinx.domains.cpp.CPPDomain,
+        sphinx.domains.javascript.JavaScriptDomain,
+        sphinx.domains.python.PythonDomain,
+    ]:
 
-            sphinx_directives += list(domain.directives) + [
-                f"{domain.name}:{item}" for item in list(domain.directives)
-            ]
-
-            sphinx_roles += list(domain.roles) + [
-                f"{domain.name}:{item}" for item in list(domain.roles)
-            ]
-    else:
-        sphinx_roles = [
-            "abbr",
-            "command",
-            "dfn",
-            "doc",
-            "download",
-            "envvar",
-            "file",
-            "guilabel",
-            "kbd",
-            "keyword",
-            "mailheader",
-            "makevar",
-            "manpage",
-            "menuselection",
-            "mimetype",
-            "newsgroup",
-            "option",
-            "program",
-            "py:func",
-            "ref",
-            "regexp",
-            "samp",
-            "term",
-            "token",
+        sphinx_directives += list(domain.directives) + [
+            f"{domain.name}:{item}" for item in list(domain.directives)
         ]
 
-        sphinx_directives = [
-            "autosummary",
-            "currentmodule",
-            "centered",
-            "c:function",
-            "c:type",
-            "include",
-            "deprecated",
-            "envvar",
-            "glossary",
-            "index",
-            "no-code-block",
-            "literalinclude",
-            "hlist",
-            "option",
-            "productionlist",
-            "py:function",
-            "seealso",
-            "toctree",
-            "todo",
-            "versionadded",
-            "versionchanged",
+        sphinx_roles += list(domain.roles) + [
+            f"{domain.name}:{item}" for item in list(domain.roles)
         ]
+
+    return (sphinx_directives, sphinx_roles)
+
+
+def _get_default_directives_and_roles_for_sphinx() -> typing.Tuple[
+    typing.List[str], typing.List[str]
+]:
+    """Return a tuple of default Sphinx directive and roles."""
+    sphinx_roles = [
+        "abbr",
+        "command",
+        "dfn",
+        "doc",
+        "download",
+        "envvar",
+        "file",
+        "guilabel",
+        "kbd",
+        "keyword",
+        "mailheader",
+        "makevar",
+        "manpage",
+        "menuselection",
+        "mimetype",
+        "newsgroup",
+        "option",
+        "program",
+        "py:func",
+        "ref",
+        "regexp",
+        "samp",
+        "term",
+        "token",
+    ]
+
+    sphinx_directives = [
+        "autosummary",
+        "currentmodule",
+        "centered",
+        "c:function",
+        "c:type",
+        "include",
+        "deprecated",
+        "envvar",
+        "glossary",
+        "index",
+        "no-code-block",
+        "literalinclude",
+        "hlist",
+        "option",
+        "productionlist",
+        "py:function",
+        "seealso",
+        "toctree",
+        "todo",
+        "versionadded",
+        "versionchanged",
+    ]
 
     return (sphinx_directives, sphinx_roles)
 

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -859,11 +859,6 @@ def parse_args() -> argparse.Namespace:
         "-r", "--recursive", action="store_true", help="run recursively over directories"
     )
     parser.add_argument(
-        "--use-sphinx-defaults",
-        action="store_true",
-        help="run with default values for sphinx when it is not available",
-    )
-    parser.add_argument(
         "--report",
         metavar="level",
         choices=threshold_choices,

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -433,6 +433,7 @@ def _get_default_directives_and_roles_for_sphinx() -> typing.Tuple[
 
     sphinx_directives = [
         "autosummary",
+        "code-block",
         "currentmodule",
         "centered",
         "c:function",

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -413,8 +413,10 @@ def _get_directives_and_roles_from_sphinx() -> typing.Tuple[typing.List[str], ty
     sphinx_roles += list(
         sphinx.application.docutils.roles._roles  # pylint: disable=protected-access
     )
-    sphinx_directives.remove("code")
-    sphinx_directives.remove("code-block")
+    if "code" in sphinx_directives:
+        sphinx_directives.remove("code")
+    if "code-block" in sphinx_directives:
+        sphinx_directives.remove("code-block")
 
     return (sphinx_directives, sphinx_roles)
 

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -508,31 +508,22 @@ def _ignore_role(
     return ([], [])
 
 
-def ignore_sphinx() -> None:
+def ignore_sphinx(use_sphinx_defaults: bool = False) -> None:
     """Register Sphinx directives and roles to ignore."""
-    (directives, roles) = _get_directives_and_roles_from_sphinx()
+    directives: typing.List[str] = []
+    roles: typing.List[str] = []
 
-    directives += [
-        "centered",
-        "include",
-        "deprecated",
-        "index",
-        "no-code-block",
-        "literalinclude",
-        "hlist",
-        "seealso",
-        "toctree",
-        "todo",
-        "versionadded",
-        "versionchanged",
-    ]
+    if SPHINX_INSTALLED:
+        (directives, roles) = _get_directives_and_roles_from_sphinx()
+    elif use_sphinx_defaults:
+        (directives, roles) = _get_default_directives_and_roles_for_sphinx()
 
-    ext_autosummary = [
-        "autosummary",
-        "currentmodule",
-    ]
+    if SPHINX_INSTALLED or use_sphinx_defaults:
+        extended_ignores = _get_extended_default_directives_and_roles_for_sphinx()
+        directives += extended_ignores[0]
+        roles += extended_ignores[1]
 
-    ignore_directives_and_roles(directives + ext_autosummary, roles + ["ctype"])
+    ignore_directives_and_roles(directives, roles)
 
 
 def find_config(  # noqa: CCR001

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -452,6 +452,38 @@ def _get_default_directives_and_roles_for_sphinx() -> typing.Tuple[
     return (sphinx_directives, sphinx_roles)
 
 
+def _get_extended_default_directives_and_roles_for_sphinx() -> typing.Tuple[
+    typing.List[str], typing.List[str]
+]:
+    """Return a tuple of extended default Sphinx directive and roles.
+
+    These are used wether sphinx can be loaded or not.
+    """
+    sphinx_directives = [
+        "centered",
+        "include",
+        "deprecated",
+        "index",
+        "no-code-block",
+        "literalinclude",
+        "hlist",
+        "seealso",
+        "toctree",
+        "todo",
+        "versionadded",
+        "versionchanged",
+    ]
+
+    ext_autosummary = [
+        "autosummary",
+        "currentmodule",
+    ]
+
+    sphinx_roles = ["ctype"]
+
+    return (sphinx_directives + ext_autosummary, sphinx_roles)
+
+
 class IgnoredDirective(docutils.parsers.rst.Directive):
     """Stub for unknown directives."""
 

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -142,10 +142,7 @@ class CodeBlockDirective(docutils.parsers.rst.Directive):
 
 def register_code_directive() -> None:
     """Register code directive."""
-    if not SPHINX_INSTALLED:
-        docutils.parsers.rst.directives.register_directive("code", CodeBlockDirective)
-        docutils.parsers.rst.directives.register_directive("code-block", CodeBlockDirective)
-        docutils.parsers.rst.directives.register_directive("sourcecode", CodeBlockDirective)
+    docutils.parsers.rst.directives.register_directive("code", CodeBlockDirective)
 
 
 def strip_byte_order_mark(text: str) -> str:

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -142,7 +142,8 @@ class CodeBlockDirective(docutils.parsers.rst.Directive):
 
 def register_code_directive() -> None:
     """Register code directive."""
-    docutils.parsers.rst.directives.register_directive("code", CodeBlockDirective)
+    if not SPHINX_INSTALLED:
+        docutils.parsers.rst.directives.register_directive("code", CodeBlockDirective)
 
 
 def strip_byte_order_mark(text: str) -> str:
@@ -537,6 +538,10 @@ def load_configuration_from_file(directory: str, args: argparse.Namespace) -> ar
         directory_or_file = args.config
 
     options = _get_options(directory_or_file, debug=args.debug)
+
+    args.use_sphinx_defaults = (
+        options.get("use_sphinx_defaults", str(args.use_sphinx_defaults)).casefold() == "true"
+    )
 
     args.report = options.get("report", args.report)
     threshold_dictionary = docutils.frontend.OptionParser.thresholds

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -397,6 +397,8 @@ def _get_directives_and_roles_from_sphinx() -> typing.Tuple[typing.List[str], ty
     sphinx_roles += list(
         sphinx.application.docutils.roles._roles  # pylint: disable=protected-access
     )
+    sphinx_directives.remove("code")
+    sphinx_directives.remove("code-block")
 
     return (sphinx_directives, sphinx_roles)
 

--- a/rstcheck/__init__.py
+++ b/rstcheck/__init__.py
@@ -391,50 +391,14 @@ def _get_directives_and_roles_from_sphinx() -> typing.Tuple[typing.List[str], ty
             f"{domain.name}:{item}" for item in list(domain.roles)
         ]
 
+    sphinx_directives += list(
+        sphinx.application.docutils.directives._directives  # pylint: disable=protected-access
+    )
+    sphinx_roles += list(
+        sphinx.application.docutils.roles._roles  # pylint: disable=protected-access
+    )
+
     return (sphinx_directives, sphinx_roles)
-
-
-def _get_extended_default_directives_and_roles_for_sphinx() -> typing.Tuple[
-    typing.List[str], typing.List[str]
-]:
-    """Return a tuple of Sphinx directive and roles.
-
-    These directive and roles cannot be loaded like the domain ones in
-    `_get_directives_and_roles_from_sphinx()`.
-
-    https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html
-    """
-    sphinx_base_directives = [
-        "centered",
-        "code-block",
-        "codeauthor",
-        "deprecated",
-        "highlight",
-        "hlist",
-        "include",
-        "index",
-        "literalinclude",
-        "math",
-        "note",
-        "only",
-        "rubric",
-        "seealso",
-        "sectionauthor",
-        "tabularcolumns",
-        "toctree",
-        "versionadded",
-        "versionchanged",
-        "warning",
-    ]
-
-    ext_autosummary = [
-        "autosummary",
-        "currentmodule",
-    ]
-
-    sphinx_base_roles = ["ctype"]
-
-    return (sphinx_base_directives + ext_autosummary, sphinx_base_roles)
 
 
 class IgnoredDirective(docutils.parsers.rst.Directive):
@@ -467,10 +431,6 @@ def load_ignore_sphinx() -> None:
         return
 
     (directives, roles) = _get_directives_and_roles_from_sphinx()
-
-    extended_ignores = _get_extended_default_directives_and_roles_for_sphinx()
-    directives += extended_ignores[0]
-    roles += extended_ignores[1]
 
     ignore_directives_and_roles(directives, roles)
 

--- a/tests/test_as_cli_tool.py
+++ b/tests/test_as_cli_tool.py
@@ -6,6 +6,8 @@ import typing
 
 import pytest
 
+import rstcheck
+
 
 REPO_DIR = pathlib.Path(__file__).resolve().parents[1]
 
@@ -324,3 +326,61 @@ class TestConfigFromOtherDirCanBeUsed:
         )
 
         assert result.returncode == 0
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Buggy on windows and macos.")
+@pytest.mark.skipif(rstcheck.SPHINX_INSTALLED, reason="Run only without sphinx.")
+def test_sphinx_role_erros_without_sphinx() -> None:
+    """Test sphinx example errors without sphinx."""
+    result = subprocess.run(  # pylint: disable=subprocess-run-check # noqa: S603,S607
+        [
+            "rstcheck",
+            "examples/sphinx/good.rst",
+        ]
+    )
+
+    assert result.returncode != 0
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Buggy on windows and macos.")
+@pytest.mark.skipif(rstcheck.SPHINX_INSTALLED, reason="Run only without sphinx.")
+def test_sphinx_role_exits_zero_without_sphinx_but_defaults() -> None:
+    """Test sphinx example errors without sphinx."""
+    result = subprocess.run(  # pylint: disable=subprocess-run-check # noqa: S603,S607
+        [
+            "rstcheck",
+            "--use-sphinx-defaults",
+            "examples/sphinx/good.rst",
+        ]
+    )
+
+    assert result.returncode == 0
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Buggy on windows and macos.")
+@pytest.mark.skipif(not rstcheck.SPHINX_INSTALLED, reason="Run only with sphinx.")
+def test_sphinx_role_exits_zero_with_sphinx() -> None:
+    """Test sphinx example errors without sphinx."""
+    result = subprocess.run(  # pylint: disable=subprocess-run-check # noqa: S603,S607
+        [
+            "rstcheck",
+            "examples/sphinx/good.rst",
+        ]
+    )
+
+    assert result.returncode == 0
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Buggy on windows and macos.")
+@pytest.mark.skipif(not rstcheck.SPHINX_INSTALLED, reason="Run only with sphinx.")
+def test_sphinx_role_exits_zero_with_sphinx_and_defaults() -> None:
+    """Test sphinx example errors without sphinx."""
+    result = subprocess.run(  # pylint: disable=subprocess-run-check # noqa: S603,S607
+        [
+            "rstcheck",
+            "--use-sphinx-defaults",
+            "examples/sphinx/good.rst",
+        ]
+    )
+
+    assert result.returncode == 0

--- a/tests/test_as_cli_tool.py
+++ b/tests/test_as_cli_tool.py
@@ -343,42 +343,12 @@ def test_sphinx_role_erros_without_sphinx() -> None:
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Buggy on windows and macos.")
-@pytest.mark.skipif(rstcheck.SPHINX_INSTALLED, reason="Run only without sphinx.")
-def test_sphinx_role_exits_zero_without_sphinx_but_defaults() -> None:
-    """Test sphinx example errors without sphinx."""
-    result = subprocess.run(  # pylint: disable=subprocess-run-check # noqa: S603,S607
-        [
-            "rstcheck",
-            "--use-sphinx-defaults",
-            "examples/sphinx/good.rst",
-        ]
-    )
-
-    assert result.returncode == 0
-
-
-@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Buggy on windows and macos.")
 @pytest.mark.skipif(not rstcheck.SPHINX_INSTALLED, reason="Run only with sphinx.")
 def test_sphinx_role_exits_zero_with_sphinx() -> None:
     """Test sphinx example errors without sphinx."""
     result = subprocess.run(  # pylint: disable=subprocess-run-check # noqa: S603,S607
         [
             "rstcheck",
-            "examples/sphinx/good.rst",
-        ]
-    )
-
-    assert result.returncode == 0
-
-
-@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Buggy on windows and macos.")
-@pytest.mark.skipif(not rstcheck.SPHINX_INSTALLED, reason="Run only with sphinx.")
-def test_sphinx_role_exits_zero_with_sphinx_and_defaults() -> None:
-    """Test sphinx example errors without sphinx."""
-    result = subprocess.run(  # pylint: disable=subprocess-run-check # noqa: S603,S607
-        [
-            "rstcheck",
-            "--use-sphinx-defaults",
             "examples/sphinx/good.rst",
         ]
     )

--- a/tests/test_rstcheck.py
+++ b/tests/test_rstcheck.py
@@ -87,7 +87,7 @@ def test_check_code_block() -> None:
 Test
 ====
 
-.. code-block:: python
+.. code:: python
 
     print(
 """
@@ -108,7 +108,7 @@ def test_check_json() -> None:
 Test
 ====
 
-.. code-block:: json
+.. code:: json
 
     {
         'abc': 123
@@ -129,7 +129,7 @@ def test_check_json_with_ignore() -> None:
 Test
 ====
 
-.. code-block:: json
+.. code:: json
 
     {
         'abc': 123
@@ -154,7 +154,7 @@ def test_check_json_with_unmatched_ignores_only() -> None:
 Test
 ====
 
-.. code-block:: json
+.. code:: json
 
     {
         'abc': 123
@@ -180,7 +180,7 @@ def test_check_json_with_bad_ignore() -> None:
 Test
 ====
 
-.. code-block:: json
+.. code:: json
 
     {
         'abc': 123
@@ -205,7 +205,7 @@ def test_check_xml() -> None:
 Test
 ====
 
-.. code-block:: xml
+.. code:: xml
 
     <?xml version="1.0" encoding="UTF-8"?>
     <root>
@@ -227,7 +227,7 @@ def test_check_xml_with_ignore() -> None:
 Test
 ====
 
-.. code-block:: xml
+.. code:: xml
 
     <?xml version="1.0" encoding="UTF-8"?>
     <root>
@@ -253,7 +253,7 @@ def test_check_xml_with_unmatched_ignores_only() -> None:
 Test
 ====
 
-.. code-block:: xml
+.. code:: xml
 
     <?xml version="1.0" encoding="UTF-8"?>
     <root>
@@ -280,7 +280,7 @@ def test_check_xml_with_bad_ignore() -> None:
 Test
 ====
 
-.. code-block:: xml
+.. code:: xml
 
     <?xml version="1.0" encoding="UTF-8"?>
     <root>
@@ -306,7 +306,7 @@ def test_check_with_extra_blank_lines_before() -> None:
 Test
 ====
 
-.. code-block:: python
+.. code:: python
 
 
 
@@ -329,7 +329,7 @@ def test_check_with_extra_blank_lines_after() -> None:
 Test
 ====
 
-.. code-block:: python
+.. code:: python
 
     print(
 
@@ -353,7 +353,7 @@ def test_check_with_extra_blank_lines_before_and_after() -> None:
 Test
 ====
 
-.. code-block:: python
+.. code:: python
 
 
 
@@ -412,33 +412,33 @@ def test_check_nested_rst() -> None:
 Test
 ====
 
-.. code-block:: rst
+.. code:: rst
 
     Test
     ====
 
-    .. code-block:: rst
+    .. code:: rst
 
 
         Test
         ====
 
-        .. code-block:: rst
+        .. code:: rst
 
             Test
             ====
 
-            .. code-block:: rst
+            .. code:: rst
 
                 Test
                 ====
 
-                .. code-block:: rst
+                .. code:: rst
 
                     Test
                     ====
 
-                    .. code-block:: python
+                    .. code:: python
 
                         print(
 """
@@ -471,12 +471,12 @@ def test_ignore_sphinx_directives() -> None:
 
    print('Hello')
 
-.. code-block:: ruby
+.. code:: ruby
    :linenos:
 
    puts "Hello!"
 
-.. code-block:: python
+.. code:: python
    :linenos:
    :emphasize-lines: 3,5
 
@@ -594,7 +594,7 @@ def test_check_doctest_in_code_block() -> None:
 Testing
 =======
 
-.. code-block:: doctest
+.. code:: doctest
 
     >>> x = 1
     >>>> x
@@ -617,7 +617,7 @@ def test_check_doctest_in_python_code_block() -> None:
 Testing
 =======
 
-.. code-block:: python
+.. code:: python
 
     >>> x = 1
     >>>> x

--- a/tests/test_rstcheck.py
+++ b/tests/test_rstcheck.py
@@ -6,10 +6,6 @@ import pytest
 import rstcheck
 
 
-# We don't do this in the module itself to avoid mutation.
-rstcheck.ignore_sphinx(True)
-
-
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
 def test_parse_gcc_style_error_message() -> None:
     """Test `parse_gcc_style_error_message`."""

--- a/tests/test_rstcheck.py
+++ b/tests/test_rstcheck.py
@@ -57,8 +57,9 @@ def test_check() -> None:
         6,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -66,9 +67,10 @@ Test
 
     print(
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -78,8 +80,9 @@ def test_check_code_block() -> None:
         6,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -87,9 +90,10 @@ Test
 
     print(
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -99,8 +103,9 @@ def test_check_json() -> None:
         7,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -110,9 +115,10 @@ Test
         'abc': 123
     }
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -120,8 +126,9 @@ def test_check_json_with_ignore() -> None:
     """Test `check` with json and ignore."""
     line_numbers: typing.Set[int] = set()
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -133,9 +140,10 @@ Test
 
 .. rstcheck: ignore-language=json,python,rst
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -145,8 +153,9 @@ def test_check_json_with_unmatched_ignores_only() -> None:
         7,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -158,9 +167,10 @@ Test
 
 .. rstcheck: ignore-language=cpp,python,rst
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -171,8 +181,9 @@ def test_check_json_with_bad_ignore() -> None:
         10,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -184,9 +195,10 @@ Test
 
 .. rstcheck: ignore-language json,python,rst
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -196,8 +208,9 @@ def test_check_xml() -> None:
         8,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -208,9 +221,10 @@ Test
        </abc>123<abc>
     </root>
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -218,8 +232,9 @@ def test_check_xml_with_ignore() -> None:
     """Test `check` with xml and ignore."""
     line_numbers: typing.Set[int] = set()
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -232,9 +247,10 @@ Test
 
 .. rstcheck: ignore-language=xml,python,rst
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -244,8 +260,9 @@ def test_check_xml_with_unmatched_ignores_only() -> None:
         8,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -258,9 +275,10 @@ Test
 
 .. rstcheck: ignore-language=cpp,python,rst
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -271,8 +289,9 @@ def test_check_xml_with_bad_ignore() -> None:
         11,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -285,9 +304,10 @@ Test
 
 .. rstcheck: ignore-language xml,python,rst
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -297,8 +317,9 @@ def test_check_with_extra_blank_lines_before() -> None:
         8,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -308,9 +329,10 @@ Test
 
     print(
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -320,8 +342,9 @@ def test_check_with_extra_blank_lines_after() -> None:
         6,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -332,9 +355,10 @@ Test
 
 
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -344,8 +368,9 @@ def test_check_with_extra_blank_lines_before_and_after() -> None:
         8,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -358,9 +383,10 @@ Test
 
 
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -370,14 +396,16 @@ def test_check_rst() -> None:
         2,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ===
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -385,15 +413,17 @@ def test_check_rst_report_level() -> None:
     """Test `check` with rst and set report level."""
     line_numbers: typing.Set[int] = set()
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ===
 """,
-        report_level=5,
+            report_level=5,
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -403,8 +433,9 @@ def test_check_nested_rst() -> None:
         32,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Test
 ====
 
@@ -438,9 +469,10 @@ Test
 
                         print(
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.skipif(not rstcheck.SPHINX_INSTALLED, reason="Requires Sphinx")
@@ -449,8 +481,9 @@ def test_ignore_sphinx_directives() -> None:
     """Test `check` with sphinx directives to ignore."""
     line_numbers: typing.Set[int] = set()
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 .. toctree::
     :maxdepth: 2
 
@@ -487,9 +520,10 @@ def test_ignore_sphinx_directives() -> None:
    :linenos:
 
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -499,8 +533,9 @@ def test_check_doctest() -> None:
         5,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Testing
 =======
 
@@ -508,9 +543,10 @@ Testing
 >>>> x
 1
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -538,8 +574,9 @@ def test_check_doctest_with_ignore() -> None:
     """Test `check` with doctest and ignore."""
     line_numbers: typing.Set[int] = set()
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Testing
 =======
 
@@ -549,9 +586,10 @@ Testing
 
 .. rstcheck: ignore-language=doctest
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.skipif(rstcheck.SPHINX_INSTALLED, reason="Does not work with Sphinx")
@@ -562,8 +600,9 @@ def test_check_doctest_in_code() -> None:
         7,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Testing
 =======
 
@@ -573,9 +612,10 @@ Testing
     >>>> x
     1
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
@@ -585,8 +625,9 @@ def test_check_doctest_in_code_block() -> None:
         7,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Testing
 =======
 
@@ -596,9 +637,10 @@ Testing
     >>>> x
     1
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)
 
 
 @pytest.mark.skipif(not rstcheck.SPHINX_INSTALLED, reason="Requires Sphinx")
@@ -609,8 +651,9 @@ def test_check_doctest_in_python_code_block() -> None:
         7,
     }
 
-    result = rstcheck.check(
-        """\
+    result = dict(
+        rstcheck.check(
+            """\
 Testing
 =======
 
@@ -620,6 +663,7 @@ Testing
     >>>> x
     1
 """
+        )
     )
 
-    assert line_numbers == set(dict(result))
+    assert line_numbers == set(result)

--- a/tests/test_rstcheck.py
+++ b/tests/test_rstcheck.py
@@ -500,12 +500,12 @@ def test_ignore_sphinx_directives() -> None:
 
    print('Hello')
 
-.. code:: ruby
+.. code-block:: ruby
    :linenos:
 
    puts "Hello!"
 
-.. code:: python
+.. code-block:: python
    :linenos:
    :emphasize-lines: 3,5
 

--- a/tests/test_rstcheck.py
+++ b/tests/test_rstcheck.py
@@ -601,6 +601,7 @@ Testing
     assert line_numbers == set(dict(result))
 
 
+@pytest.mark.skipif(not rstcheck.SPHINX_INSTALLED, reason="Requires Sphinx")
 @pytest.mark.usefixtures("enable_sphinx_if_possible")
 def test_check_doctest_in_python_code_block() -> None:
     """I'm not sure if this is correct, but I've seen people do it."""
@@ -613,7 +614,7 @@ def test_check_doctest_in_python_code_block() -> None:
 Testing
 =======
 
-.. code:: python
+.. code-block:: python
 
     >>> x = 1
     >>>> x

--- a/tests/test_rstcheck.py
+++ b/tests/test_rstcheck.py
@@ -7,7 +7,7 @@ import rstcheck
 
 
 # We don't do this in the module itself to avoid mutation.
-rstcheck.ignore_sphinx()
+rstcheck.ignore_sphinx(True)
 
 
 @pytest.mark.usefixtures("enable_sphinx_if_possible")

--- a/tox.ini
+++ b/tox.ini
@@ -13,15 +13,15 @@ envlist =
     package
     pre-commit
     py{310,39,38,37}
-    py{310,39,38,37}-with-sphinx{1.5,2,3,4}
+    py{310,39,38,37}-with-sphinx{2,3,4}
 
 
 [envlists]
-test = py{310,39,38,37},py{310,39,38,37}-with-sphinx{1.5,2,3,4}
-py3.7 = py37,py37-with-sphinx{1.5,2,3,4}
-py3.8 = py38,py38-with-sphinx{1.5,2,3,4}
-py3.9 = py39,py39-with-sphinx{1.5,2,3,4}
-py3.10 = py310,py310-with-sphinx{1.5,2,3,4},package
+test = py{310,39,38,37},py{310,39,38,37}-with-sphinx{2,3,4}
+py3.7 = py37,py37-with-sphinx{2,3,4}
+py3.8 = py38,py38-with-sphinx{2,3,4}
+py3.9 = py39,py39-with-sphinx{2,3,4}
+py3.10 = py310,py310-with-sphinx{2,3,4},package
 
 
 [testenv]
@@ -95,16 +95,15 @@ commands =
     python -m doctest -v README.rst rstcheck/__init__.py
     rstcheck README.rst --config .rstcheck.project.cfg
 
-[testenv:py{310,39,38,37}-with-sphinx{1.5,2,3,4}]
+[testenv:py{310,39,38,37}-with-sphinx{2,3,4}]
 description = run tests with {basepython} and sphinx
 passenv =
     {[testenv]passenv}
     PYTEST_*
 extras = testing
 deps =
-    sphinx1.5,sphinx2,sphinx3: jinja2<3
-    sphinx1.5,sphinx2,sphinx3: markupsafe<2
-    sphinx1.5: sphinx>=1.5,<2
+    sphinx2,sphinx3: jinja2<3
+    sphinx2,sphinx3: markupsafe<2
     sphinx2: sphinx>=2,<3
     sphinx3: sphinx>=3,<4
     # With python 3.10 there is a failing import added in sphinx 3.5


### PR DESCRIPTION
<!-- PLEASE READ !!!

    The checklist below is just a reminder about the most common mistakes.
    and should *not* deter you from submitting but rather *help* you improve your contribution.
    But please tick all the boxes appropriately.

-->

# Check List

Resolves: #<issue number here>

- [x] I added **tests** for the changed code.
- [x] I updated the **documentation** for the changed code.
- [x] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [x] I added the change to the History section on the README.

<!--
    Please add further information below that may help
    the maintainers understand what you intend to solve.
-->

This PR will be a major rework how sphinx is integrated in rstcheck. It aims to fix multiple issues and make rstcheck more generic by default. sphinx integration will then be a opt-in feature and no defaults will be loaded by default.

Out-in will be either:
- the `--use-sphinx-defaults` flag for CLI
- the `use_sphinx_defaults` option in the config file with a bool
- sphinx being install in the environment from which rstcheck is invoked so that it can be imported

Fixes #79 
Fixes #65
Fixes #62

This is planned to be release with version 6.0